### PR TITLE
Laravel 8.x is supported now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,15 +32,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           - php: '7.3'
             setup: basic
             coverage: no
-            laravel: '~5.7.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '~5.8.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '^6.0'
+            laravel: '^7.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v2.3.0
+
+### Changed
+
+- Laravel `8.x` is supported now
+- Minimal `illuminate/*` package versions now is `^6.0`
+
 ## v2.2.0
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.23-alpine
+FROM php:7.3.5-alpine
 
 ENV \
     # <https://github.com/alanxz/rabbitmq-c>
@@ -8,7 +8,7 @@ ENV \
     COMPOSER_ALLOW_SUPERUSER="1" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:1.10.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10.10 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
@@ -27,7 +27,7 @@ RUN set -x \
     # workaround for rabbitmq linking issue
     && ln -s /usr/lib /usr/local/lib64 \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-2.9.1 1>/dev/null \
+    && pecl install xdebug-2.9.6 1>/dev/null \
     # this c-library is required for 'php-amqp'
     && ( git clone --branch v${RABBITMQ_VERSION} https://github.com/alanxz/rabbitmq-c.git /tmp/rabbitmq \
         && cd /tmp/rabbitmq \

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,8 @@
 # Makefile readme (ru): <http://linux.yaroslavl.ru/docs/prog/gnu_make_3-79_russian_manual.html>
 # Makefile readme (en): <https://www.gnu.org/software/make/manual/html_node/index.html#SEC_Contents>
 
-dc_bin := $(shell command -v docker-compose 2> /dev/null)
-
 SHELL = /bin/sh
-RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)" app
+RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)"
 
 .PHONY : help latest lowest test test-cover up down shell
 .DEFAULT_GOAL : help
@@ -16,32 +14,31 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: ## Build docker images, required for current package environment
-	$(dc_bin) build
+	docker-compose build
 
 latest: clean ## Install latest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
 
 install: clean ## Install regular php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --prefer-dist --no-interaction --no-suggest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction --no-suggest
 
 lowest: clean ## Install lowest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
 
 test: up ## Execute php tests and linters
-	$(dc_bin) run $(RUN_APP_ARGS) sh -c "sleep 5 && composer test"
+	docker-compose run $(RUN_APP_ARGS) app sh -c "sleep 5 && composer test"
 
 test-cover: up ## Execute php tests with coverage
-	$(dc_bin) run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
+	docker-compose run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 up: ## Start services
-	$(dc_bin) up -d
+	docker-compose up -d
 
 down: ## Stop services
-	$(dc_bin) down
+	docker-compose down
 
 shell: ## Start shell into container with php
-	$(dc_bin) run -e "PS1=\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]" \
-    $(RUN_APP_ARGS) sh
+	docker-compose run $(RUN_APP_ARGS) app sh
 
 clean: ## Remove all dependencies and unimportant files
 	-rm -Rf ./composer.lock ./vendor ./coverage

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
     "require": {
         "php": "^7.2",
         "ext-amqp": "*",
-        "illuminate/support": "^5.6 || ~6.0 || ~7.0",
-        "illuminate/console": "^5.6 || ~6.0 || ~7.0",
-        "illuminate/events": "^5.6 || ~6.0 || ~7.0",
+        "illuminate/support": "~6.0 || ~7.0 || ~8.0",
+        "illuminate/console": "~6.0 || ~7.0 || ~8.0",
+        "illuminate/events": "~6.0 || ~7.0 || ~8.0",
         "symfony/console": "^4.4 || ~5.0",
         "enqueue/amqp-ext": "^0.9",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {
-        "laravel/laravel": "^5.6 || ~6.0 || ~7.0",
-        "phpunit/phpunit": "~7.5",
+        "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
+        "phpunit/phpunit": "^8.5.4 || ^9.3",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "^0.12"
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     environment:
       RABBIT_HOST: rabbitmq
       RABBIT_PORT: 5672
+      PS1: '\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]'
     depends_on:
       - rabbitmq
     networks:

--- a/tests/ConnectionsFactoryTest.php
+++ b/tests/ConnectionsFactoryTest.php
@@ -143,7 +143,7 @@ class ConnectionsFactoryTest extends AbstractTestCase
     public function testExceptionThrownWhenDefaultDriverIsNotSet(): void
     {
         $this->expectException(FactoryException::class);
-        $this->expectExceptionMessageRegExp('~default.*not.*set~i');
+        $this->expectExceptionMessageMatches('~default.*not.*set~i');
 
         $this->factory = new ConnectionsFactory($this->connections_settings, $this->connection_defaults);
 

--- a/tests/ExchangesFactoryTest.php
+++ b/tests/ExchangesFactoryTest.php
@@ -87,7 +87,7 @@ class ExchangesFactoryTest extends AbstractTestCase
     public function testExceptionThrownWhenPassedWrongExchangeName(): void
     {
         $this->expectException(FactoryException::class);
-        $this->expectExceptionMessageRegExp('~exchange.*not.?exists~i');
+        $this->expectExceptionMessageMatches('~exchange.*not.?exists~i');
 
         $this->factory->make(Str::random());
     }
@@ -98,7 +98,7 @@ class ExchangesFactoryTest extends AbstractTestCase
     public function testExceptionThrownWhenExchangeDeclaredWithoutName(): void
     {
         $this->expectException(FactoryException::class);
-        $this->expectExceptionMessageRegExp('~exchange.*not.?set~i');
+        $this->expectExceptionMessageMatches('~exchange.*not.?set~i');
 
         $this->factory = new ExchangesFactory([
             'foo' => [
@@ -118,7 +118,7 @@ class ExchangesFactoryTest extends AbstractTestCase
     public function testExceptionThrownWhenExchangeDeclaredWithEmptyName(): void
     {
         $this->expectException(FactoryException::class);
-        $this->expectExceptionMessageRegExp('~exchange.*not.?set~i');
+        $this->expectExceptionMessageMatches('~exchange.*not.?set~i');
 
         $this->factory = new ExchangesFactory([
             'foo' => [

--- a/tests/QueuesFactoryTest.php
+++ b/tests/QueuesFactoryTest.php
@@ -86,7 +86,7 @@ class QueuesFactoryTest extends AbstractTestCase
     public function testExceptionThrownWhenPassedWrongQueueName(): void
     {
         $this->expectException(FactoryException::class);
-        $this->expectExceptionMessageRegExp('~queue.*not.?exists~i');
+        $this->expectExceptionMessageMatches('~queue.*not.?exists~i');
 
         $this->factory->make(Str::random());
     }
@@ -97,7 +97,7 @@ class QueuesFactoryTest extends AbstractTestCase
     public function testExceptionThrownWhenQueueDeclaredWithoutName(): void
     {
         $this->expectException(FactoryException::class);
-        $this->expectExceptionMessageRegExp('~queue.*not.?set~i');
+        $this->expectExceptionMessageMatches('~queue.*not.?set~i');
 
         $this->factory = new QueuesFactory([
             'foo' => [
@@ -117,7 +117,7 @@ class QueuesFactoryTest extends AbstractTestCase
     public function testExceptionThrownWhenQueueDeclaredWithEmptyName(): void
     {
         $this->expectException(FactoryException::class);
-        $this->expectExceptionMessageRegExp('~queue.*not.?set~i');
+        $this->expectExceptionMessageMatches('~queue.*not.?set~i');
 
         $this->factory = new QueuesFactory([
             'foo' => [


### PR DESCRIPTION
## Description

### Changed

- Laravel `8.x` is supported now
- Minimal `illuminate/*` package versions now is `^6.0`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
