### PR TITLE
Change deprecated methods

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.3', '7.4']
         include:
           - php: '7.3'
             setup: basic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
+- Minimal required PHP version now is `7.3`
+- Minimal `symfony/*` version now is `5.0`
+- Minimal `phpunit/phpunit` package versions now is `9.3`
+- Version of `composer` in docker container updated up to `2.2.4`
 - Deprecated methods `assertRegExp`, `assertNotRegExp` to `assertMatchesRegularExpression`, `assertDoesNotMatchRegularExpression` [#11]
 
 [#11]:https://github.com/avto-dev/amqp-rabbit-manager/issues/11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Changed
+
+- Deprecated methods `assertRegExp`, `assertNotRegExp` to `assertMatchesRegularExpression`, `assertDoesNotMatchRegularExpression` [#11]
+
+[#11]:https://github.com/avto-dev/amqp-rabbit-manager/issues/11
+
 ## v2.4.0
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV \
     PHP_AMQP_VERSION="1.10.2" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.0.12 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.2.4 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \

--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,18 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-amqp": "*",
         "illuminate/support": "~6.0 || ~7.0 || ~8.0",
         "illuminate/console": "~6.0 || ~7.0 || ~8.0",
         "illuminate/events": "~6.0 || ~7.0 || ~8.0",
-        "symfony/console": "^4.4 || ~5.0",
+        "symfony/console": "~5.0",
         "enqueue/amqp-ext": "^0.9",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {
         "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
-        "phpunit/phpunit": "^8.5.4 || ^9.3",
+        "phpunit/phpunit": "^9.3",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "^0.12"
     },

--- a/tests/Commands/RabbitSetupCommandTest.php
+++ b/tests/Commands/RabbitSetupCommandTest.php
@@ -128,18 +128,18 @@ class RabbitSetupCommandTest extends AbstractCommandTestCase
 
         foreach ($this->setup_map as $connection_name => $settings) {
             $connection_name_safe = \preg_quote($connection_name, '/');
-            $this->assertRegExp("~^.+connection.*{$connection_name_safe}.*$~ium", $output);
+            $this->assertMatchesRegularExpression("~^.+connection.*{$connection_name_safe}.*$~ium", $output);
 
             foreach ($settings['queues'] as $queue_id) {
                 $queue_id_safe = \preg_quote($queue_id, '/');
-                $this->assertRegExp("~^.*Create queue.+{$queue_id_safe}.*$~ium", $output);
-                $this->assertNotRegExp("~^.*Delete queue.+{$queue_id_safe}.*$~ium", $output);
+                $this->assertMatchesRegularExpression("~^.*Create queue.+{$queue_id_safe}.*$~ium", $output);
+                $this->assertDoesNotMatchRegularExpression("~^.*Delete queue.+{$queue_id_safe}.*$~ium", $output);
             }
 
             foreach ($settings['exchanges'] as $exchange_id) {
                 $exchange_id_safe = \preg_quote($exchange_id, '/');
-                $this->assertRegExp("~^.*Create exchange.+{$exchange_id_safe}.*$~ium", $output);
-                $this->assertNotRegExp("~^.*Delete exchange.+{$exchange_id_safe}.*$~ium", $output);
+                $this->assertMatchesRegularExpression("~^.*Create exchange.+{$exchange_id_safe}.*$~ium", $output);
+                $this->assertDoesNotMatchRegularExpression("~^.*Delete exchange.+{$exchange_id_safe}.*$~ium", $output);
             }
         }
     }
@@ -167,11 +167,11 @@ class RabbitSetupCommandTest extends AbstractCommandTestCase
         $this->assertSame(0, $this->artisan($this->command_signature));
         $output = $this->console()->output();
 
-        $this->assertNotRegExp('~^.+connection.*$~ium', $output);
-        $this->assertNotRegExp('~^.*Create queue.*$~ium', $output);
-        $this->assertNotRegExp('~^.*Delete queue.*$~ium', $output);
-        $this->assertNotRegExp('~^.*Create exchange.*$~ium', $output);
-        $this->assertNotRegExp('~^.*Delete exchange.*$~ium', $output);
+        $this->assertDoesNotMatchRegularExpression('~^.+connection.*$~ium', $output);
+        $this->assertDoesNotMatchRegularExpression('~^.*Create queue.*$~ium', $output);
+        $this->assertDoesNotMatchRegularExpression('~^.*Delete queue.*$~ium', $output);
+        $this->assertDoesNotMatchRegularExpression('~^.*Create exchange.*$~ium', $output);
+        $this->assertDoesNotMatchRegularExpression('~^.*Delete exchange.*$~ium', $output);
     }
 
     /**
@@ -192,8 +192,8 @@ class RabbitSetupCommandTest extends AbstractCommandTestCase
         ]));
         $output = $this->console()->output();
 
-        $this->assertRegExp('~data.+lost~i', $output);
-        $this->assertRegExp('~Command.+cancel~i', $output);
+        $this->assertMatchesRegularExpression('~data.+lost~i', $output);
+        $this->assertMatchesRegularExpression('~Command.+cancel~i', $output);
     }
 
     /**
@@ -216,22 +216,22 @@ class RabbitSetupCommandTest extends AbstractCommandTestCase
         ]));
         $output = $this->console()->output();
 
-        $this->assertNotRegExp('~data.+lost~i', $output); // Alert banner should not shown
+        $this->assertDoesNotMatchRegularExpression('~data.+lost~i', $output); // Alert banner should not shown
 
         foreach ($this->setup_map as $connection_name => $settings) {
             $connection_name_safe = \preg_quote($connection_name, '/');
-            $this->assertRegExp("~^.+connection.*{$connection_name_safe}.*$~ium", $output);
+            $this->assertMatchesRegularExpression("~^.+connection.*{$connection_name_safe}.*$~ium", $output);
 
             foreach ($settings['queues'] as $queue_id) {
                 $queue_id_safe = \preg_quote($queue_id, '/');
-                $this->assertRegExp("~^.*Create queue.+{$queue_id_safe}.*$~ium", $output);
-                $this->assertRegExp("~^.*Delete queue.+{$queue_id_safe}.*$~ium", $output);
+                $this->assertMatchesRegularExpression("~^.*Create queue.+{$queue_id_safe}.*$~ium", $output);
+                $this->assertMatchesRegularExpression("~^.*Delete queue.+{$queue_id_safe}.*$~ium", $output);
             }
 
             foreach ($settings['exchanges'] as $exchange_id) {
                 $exchange_id_safe = \preg_quote($exchange_id, '/');
-                $this->assertRegExp("~^.*Create exchange.+{$exchange_id_safe}.*$~ium", $output);
-                $this->assertRegExp("~^.*Delete exchange.+{$exchange_id_safe}.*$~ium", $output);
+                $this->assertMatchesRegularExpression("~^.*Create exchange.+{$exchange_id_safe}.*$~ium", $output);
+                $this->assertMatchesRegularExpression("~^.*Delete exchange.+{$exchange_id_safe}.*$~ium", $output);
             }
         }
     }
@@ -258,21 +258,21 @@ class RabbitSetupCommandTest extends AbstractCommandTestCase
 
         foreach ($this->setup_map as $connection_name => $settings) {
             $connection_name_safe = \preg_quote($connection_name, '/');
-            $this->assertRegExp("~^.+connection.*{$connection_name_safe}.*$~ium", $output);
+            $this->assertMatchesRegularExpression("~^.+connection.*{$connection_name_safe}.*$~ium", $output);
 
             foreach ($settings['queues'] as $queue_id) {
                 $queue_id_safe = \preg_quote($queue_id, '/');
-                $this->assertRegExp("~^.*Skip.+{$queue_id_safe}.*$~ium", $output);
+                $this->assertMatchesRegularExpression("~^.*Skip.+{$queue_id_safe}.*$~ium", $output);
             }
 
             foreach ($settings['exchanges'] as $exchange_id) {
                 $exchange_id_safe = \preg_quote($exchange_id, '/');
-                $this->assertRegExp("~^.*Skip.+{$exchange_id_safe}.*$~ium", $output);
+                $this->assertMatchesRegularExpression("~^.*Skip.+{$exchange_id_safe}.*$~ium", $output);
             }
         }
 
-        $this->assertNotRegExp('~' . \preg_quote($random_queue_id, '/') . '~', $output);
-        $this->assertNotRegExp('~' . \preg_quote($random_exchange_id, '/') . '~', $output);
+        $this->assertDoesNotMatchRegularExpression('~' . \preg_quote($random_queue_id, '/') . '~', $output);
+        $this->assertDoesNotMatchRegularExpression('~' . \preg_quote($random_exchange_id, '/') . '~', $output);
     }
 
     /**
@@ -312,18 +312,18 @@ class RabbitSetupCommandTest extends AbstractCommandTestCase
 
         foreach ($this->setup_map as $connection_name => $settings) {
             $connection_name_safe = \preg_quote($connection_name, '/');
-            $this->assertRegExp("~^.+connection.*{$connection_name_safe}.*$~ium", $output);
+            $this->assertMatchesRegularExpression("~^.+connection.*{$connection_name_safe}.*$~ium", $output);
 
             foreach ($settings['queues'] as $queue_id) {
                 $queue_id_safe = \preg_quote($queue_id, '/');
-                $this->assertRegExp("~^.*Create queue.+{$queue_id_safe}.*$~ium", $output);
-                $this->assertNotRegExp("~^.*Skip.+{$queue_id_safe}.*$~ium", $output);
+                $this->assertMatchesRegularExpression("~^.*Create queue.+{$queue_id_safe}.*$~ium", $output);
+                $this->assertDoesNotMatchRegularExpression("~^.*Skip.+{$queue_id_safe}.*$~ium", $output);
             }
 
             foreach ($settings['exchanges'] as $exchange_id) {
                 $exchange_id_safe = \preg_quote($exchange_id, '/');
-                $this->assertRegExp("~^.*Create exchange.+{$exchange_id_safe}.*$~ium", $output);
-                $this->assertNotRegExp("~^.*Skip.+{$exchange_id_safe}.*$~ium", $output);
+                $this->assertMatchesRegularExpression("~^.*Create exchange.+{$exchange_id_safe}.*$~ium", $output);
+                $this->assertDoesNotMatchRegularExpression("~^.*Skip.+{$exchange_id_safe}.*$~ium", $output);
             }
         }
     }

--- a/tests/Exceptions/FactoryExceptionTest.php
+++ b/tests/Exceptions/FactoryExceptionTest.php
@@ -25,11 +25,11 @@ class FactoryExceptionTest extends AbstractTestCase
      */
     public function testStaticFabrics(): void
     {
-        $this->assertRegExp('~connection.*not exists~i', FactoryException::connectionNotExists('')->getMessage());
-        $this->assertRegExp('~Default.*not set~i', FactoryException::defaultConnectionNotSet()->getMessage());
-        $this->assertRegExp('~Queue.+name.*not set~i', FactoryException::queueNameNotSet('')->getMessage());
-        $this->assertRegExp('~Queue.*not exists~i', FactoryException::queueNotExists('')->getMessage());
-        $this->assertRegExp('~Exchange.+name.*not set~i', FactoryException::exchangeNameNotSet('')->getMessage());
-        $this->assertRegExp('~Exchange.*not exists~i', FactoryException::exchangeNotExists('')->getMessage());
+        $this->assertMatchesRegularExpression('~connection.*not exists~i', FactoryException::connectionNotExists('')->getMessage());
+        $this->assertMatchesRegularExpression('~Default.*not set~i', FactoryException::defaultConnectionNotSet()->getMessage());
+        $this->assertMatchesRegularExpression('~Queue.+name.*not set~i', FactoryException::queueNameNotSet('')->getMessage());
+        $this->assertMatchesRegularExpression('~Queue.*not exists~i', FactoryException::queueNotExists('')->getMessage());
+        $this->assertMatchesRegularExpression('~Exchange.+name.*not set~i', FactoryException::exchangeNameNotSet('')->getMessage());
+        $this->assertMatchesRegularExpression('~Exchange.*not exists~i', FactoryException::exchangeNotExists('')->getMessage());
     }
 }


### PR DESCRIPTION
## Description

### Changed

- Deprecated methods `assertRegExp`, `assertNotRegExp` to `assertMatchesRegularExpression`, `assertDoesNotMatchRegularExpression`

Fixes #11 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file
