### PR TITLE
Add support php 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
         include:
           - php: '7.3'
             setup: basic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Added
+
+- Support PHP `8.x`
+- Support Laravel `9.x`
+
+### Changed
+
+- XDebug version up to `3.1.5`
+- Package `alanxz/rabbitmq-c` up to `0.11`
+- Package `pdezwart/php-amqp` up to `1.11`
+- Package `enqueue/amqp-ext` up to `0.10`
+
 ## v2.5.0
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM php:7.3.5-alpine
+FROM php:8.0-alpine
 
 ENV \
     # <https://github.com/alanxz/rabbitmq-c>
-    RABBITMQ_VERSION="0.10.0" \
+    RABBITMQ_VERSION="0.11.0" \
     # ext-amqp <https://github.com/pdezwart/php-amqp>
-    PHP_AMQP_VERSION="1.10.2" \
+    PHP_AMQP_VERSION="1.11.0" \
     COMPOSER_HOME="/tmp/composer"
 
 COPY --from=composer:2.2.4 /usr/bin/composer /usr/bin/composer
@@ -26,7 +26,7 @@ RUN set -x \
     # workaround for rabbitmq linking issue
     && ln -s /usr/lib /usr/local/lib64 \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-2.9.6 1>/dev/null \
+    && pecl install xdebug-3.1.5 1>/dev/null \
     # this c-library is required for 'php-amqp'
     && ( git clone --branch v${RABBITMQ_VERSION} https://github.com/alanxz/rabbitmq-c.git /tmp/rabbitmq \
         && cd /tmp/rabbitmq \

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "ext-amqp": "*",
-        "illuminate/support": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/console": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/events": "~6.0 || ~7.0 || ~8.0",
+        "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "illuminate/console": "~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "illuminate/events": "~6.0 || ~7.0 || ~8.0 || ~9.0",
         "symfony/console": "~5.0",
-        "enqueue/amqp-ext": "^0.9",
+        "enqueue/amqp-ext": "^0.10",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {
-        "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
+        "laravel/laravel": "~6.0 || ~7.0 || ~8.0 || ~9.0",
         "phpunit/phpunit": "^9.3",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "^0.12"

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     "require-dev": {
         "laravel/laravel": "~6.0 || ~7.0 || ~8.0 || ~9.0",
         "phpunit/phpunit": "^9.3",
-        "mockery/mockery": "^1.3",
-        "phpstan/phpstan": "^0.12"
+        "mockery/mockery": "^1.3.2",
+        "phpstan/phpstan": "^0.12.34"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Description

### Added

- Support PHP `8.x`
- Support Laravel `9.x`

### Changed

- XDebug version up to `3.1.5`
- Package `alanxz/rabbitmq-c` up to `0.11`
- Package `pdezwart/php-amqp` up to `1.11`
- Package `enqueue/amqp-ext` up to `0.10`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

