### PR TITLE
Add support of symfony/console 6.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Maximal `symfony/console"` package versions now is `6.*`
+
 ## v2.6.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0",
         "illuminate/console": "~6.0 || ~7.0 || ~8.0 || ~9.0",
         "illuminate/events": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "symfony/console": "~5.0",
+        "symfony/console": "~5.0 || ~6.0",
         "enqueue/amqp-ext": "^0.10",
         "queue-interop/queue-interop": "^0.8"
     },


### PR DESCRIPTION
### Added

- Maximal `symfony/console"` package versions now is `6.*`