### PR TITLE
Update minimal versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,15 +27,10 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.3', '7.4', '8.0']
-        include:
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '^7.0'
+        php: ['8.0', '8.1', '8.2']
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -54,12 +49,12 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Get Composer Cache Directory # Docs: <https://git.io/JfAKn#php---composer>
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.3
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
@@ -86,7 +81,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         if: matrix.coverage == 'yes'
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v1 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v3 # Docs: <https://github.com/codecov/codecov-action>
         if: matrix.coverage == 'yes'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -99,7 +94,7 @@ jobs: # Docs: <https://git.io/JvxXE>
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Minimal composer PHP version is set to `8.x`
+- Package `laravel/laravel` up to `^9.0`
+- Package `illuminate/support` up to `^9.0`
+- Package `illuminate/queue` up to `^9.0`
+- Package `illuminate/container` up to `^9.0`
+- Package `illuminate/contracts` up to `^9.0`
+- Package `symfony/console` up to `^6.0`
+- Package `symphony/process` up to `^6.0`
+- Package `mockery/mockery` up to `^1.5.1`
+- Minimal `phpstan/phpstan` version now is `1.8`
+- Version of `composer` in docker container updated up to `2.5.1`
+
 ## v2.7.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV \
     PHP_AMQP_VERSION="1.11.0" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.2.4 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.5.1 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \

--- a/composer.json
+++ b/composer.json
@@ -15,20 +15,20 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0",
         "ext-amqp": "*",
-        "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "illuminate/console": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "illuminate/events": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "symfony/console": "~5.0 || ~6.0",
+        "illuminate/support": "~9.0",
+        "illuminate/console": "~9.0",
+        "illuminate/events": "~9.0",
+        "symfony/console": "~6.0",
         "enqueue/amqp-ext": "^0.10",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {
-        "laravel/laravel": "~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "laravel/laravel": "~9.0",
         "phpunit/phpunit": "^9.3",
-        "mockery/mockery": "^1.3.2",
-        "phpstan/phpstan": "^0.12.34"
+        "mockery/mockery": "^1.5.1",
+        "phpstan/phpstan": "^1.8"
     },
     "autoload": {
         "psr-4": {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -75,8 +75,10 @@ class ServiceProvider extends IlluminateServiceProvider
             function (Container $container): QueuesFactoryInterface {
                 /** @var ConfigRepository $config */
                 $config = $container->make(ConfigRepository::class);
+                /** @var array<string, array<string, mixed>> $queues */
+                $queues = (array) $config->get(static::getConfigRootKeyName() . '.queues');
 
-                return new QueuesFactory((array) $config->get(static::getConfigRootKeyName() . '.queues'));
+                return new QueuesFactory($queues);
             }
         );
     }
@@ -93,8 +95,10 @@ class ServiceProvider extends IlluminateServiceProvider
             function (Container $container): ExchangesFactoryInterface {
                 /** @var ConfigRepository $config */
                 $config = $container->make(ConfigRepository::class);
+                /** @var array<string, array<string, mixed>> $exchanges */
+                $exchanges = (array) $config->get(static::getConfigRootKeyName() . '.exchanges');
 
-                return new ExchangesFactory((array) $config->get(static::getConfigRootKeyName() . '.exchanges'));
+                return new ExchangesFactory($exchanges);
             }
         );
     }
@@ -113,10 +117,15 @@ class ServiceProvider extends IlluminateServiceProvider
                 $config = $container->make(ConfigRepository::class);
                 $root   = static::getConfigRootKeyName();
 
+                /** @var array<string, array<string, mixed>>, $connections */
+                $connections = (array) $config->get("{$root}.connections");
+                /** @var string|null $default */
+                $default = $config->get("{$root}.default_connection");
+
                 return new ConnectionsFactory(
-                    (array) $config->get("{$root}.connections"),
+                    $connections,
                     (array) $config->get("{$root}.connection_defaults"),
-                    $config->get("{$root}.default_connection")
+                    $default
                 );
             }
         );
@@ -133,6 +142,7 @@ class ServiceProvider extends IlluminateServiceProvider
             /** @var ConfigRepository $config */
             $config = $container->make(ConfigRepository::class);
 
+            /** @var Command */
             return $container->make(Commands\RabbitSetupCommand::class, [
                 'map' => $config->get(static::getConfigRootKeyName() . '.setup'),
             ]);


### PR DESCRIPTION
## Description

### Changed

- Minimal composer PHP version is set to `8.x`
- Package `laravel/laravel` up to `^9.0`
- Package `illuminate/support` up to `^9.0`
- Package `illuminate/queue` up to `^9.0`
- Package `illuminate/container` up to `^9.0`
- Package `illuminate/contracts` up to `^9.0`
- Package `symfony/console` up to `^6.0`
- Package `symphony/process` up to `^6.0`
- Package `mockery/mockery` up to `^1.5.1`
- Minimal `phpstan/phpstan` version now is `1.8`
- Version of `composer` in docker container updated up to `2.5.1`


Fixes #16 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file
