### PR TITLE
laravel 10 support 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         php: ['8.0', '8.1', '8.2']
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -52,7 +52,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v3.2.3
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
@@ -94,7 +94,7 @@ jobs: # Docs: <https://git.io/JvxXE>
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Support Laravel `10.x`
+- Support PHPUnit `v10`
+
+### Changed
+
+- Minimal require PHP version now is `8.0.2`
+- Composer version up to `2.6.5`
+- RabbitMQ version up to `0.13.0`
+- Package `mockery/mockery` up to `^1.6`
+- Package `phpstan/phpstan` up to `^1.10`
+
 ## v2.8.0
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,17 @@ FROM php:8.0-alpine
 
 ENV \
     # <https://github.com/alanxz/rabbitmq-c>
-    RABBITMQ_VERSION="0.11.0" \
+    RABBITMQ_VERSION="0.13.0" \
     # ext-amqp <https://github.com/pdezwart/php-amqp>
     PHP_AMQP_VERSION="1.11.0" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.5.1 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.6.5 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps \
+        linux-headers \
         openssl-dev \
         autoconf \
         pkgconf \
@@ -26,7 +27,7 @@ RUN set -x \
     # workaround for rabbitmq linking issue
     && ln -s /usr/lib /usr/local/lib64 \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-3.1.5 1>/dev/null \
+    && pecl install xdebug-3.2.0 1>/dev/null \
     # this c-library is required for 'php-amqp'
     && ( git clone --branch v${RABBITMQ_VERSION} https://github.com/alanxz/rabbitmq-c.git /tmp/rabbitmq \
         && cd /tmp/rabbitmq \

--- a/composer.json
+++ b/composer.json
@@ -15,20 +15,20 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.0.2",
         "ext-amqp": "*",
-        "illuminate/support": "~9.0",
-        "illuminate/console": "~9.0",
-        "illuminate/events": "~9.0",
+        "illuminate/support": "~9.0 || ~10.0",
+        "illuminate/console": "~9.0 || ~10.0",
+        "illuminate/events": "~9.0 || ~10.0",
         "symfony/console": "~6.0",
-        "enqueue/amqp-ext": "^0.10",
+        "enqueue/amqp-ext": "^0.10.8",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {
-        "laravel/laravel": "~9.0",
-        "phpunit/phpunit": "^9.3",
-        "mockery/mockery": "^1.5.1",
-        "phpstan/phpstan": "^1.8"
+        "laravel/laravel": "~9.0 || ~10.0",
+        "phpunit/phpunit": "^9.6 || ^10.4",
+        "mockery/mockery": "^1.6",
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,36 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         backupGlobals="false"
-         backupStaticAttributes="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="./tests/bootstrap.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-            <exclude>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <logging>
-        <!--log type="coverage-html" target="./coverage/html"/-->
-        <log type="coverage-xml" target="./coverage/xml"/>
-        <log type="coverage-clover" target="./coverage/clover.xml"/>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-    </logging>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="APP_DEBUG" value="true"/>
-    </php>
+         colors="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="./coverage/clover.xml"/>
+      <text outputFile="php://stdout" showUncoveredFiles="false"/>
+      <xml outputDirectory="./coverage/xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="APP_DEBUG" value="true"/>
+  </php>
 </phpunit>

--- a/tests/Commands/Events/ExchangeCreatedTest.php
+++ b/tests/Commands/Events/ExchangeCreatedTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\AmqpRabbitManager\Tests\Commands\Events;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeCreated;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeCreated<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeCreated
  */
 class ExchangeCreatedTest extends AbstractEventTestCase
 {

--- a/tests/Commands/Events/ExchangeCreatingTest.php
+++ b/tests/Commands/Events/ExchangeCreatingTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\AmqpRabbitManager\Tests\Commands\Events;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeCreating;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeCreating<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeCreating
  */
 class ExchangeCreatingTest extends AbstractEventTestCase
 {

--- a/tests/Commands/Events/ExchangeDeletedTest.php
+++ b/tests/Commands/Events/ExchangeDeletedTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\AmqpRabbitManager\Tests\Commands\Events;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeDeleted;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeDeleted<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeDeleted
  */
 class ExchangeDeletedTest extends AbstractEventTestCase
 {

--- a/tests/Commands/Events/ExchangeDeletingTest.php
+++ b/tests/Commands/Events/ExchangeDeletingTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\AmqpRabbitManager\Tests\Commands\Events;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeDeleting;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeDeleting<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeDeleting
  */
 class ExchangeDeletingTest extends AbstractEventTestCase
 {

--- a/tests/Commands/Events/QueueCreatedTest.php
+++ b/tests/Commands/Events/QueueCreatedTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\AmqpRabbitManager\Tests\Commands\Events;
 use AvtoDev\AmqpRabbitManager\Commands\Events\QueueCreated;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\QueueCreated<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\QueueCreated
  */
 class QueueCreatedTest extends AbstractEventTestCase
 {

--- a/tests/Commands/Events/QueueCreatingTest.php
+++ b/tests/Commands/Events/QueueCreatingTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\AmqpRabbitManager\Tests\Commands\Events;
 use AvtoDev\AmqpRabbitManager\Commands\Events\QueueCreating;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\QueueCreating<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\QueueCreating
  */
 class QueueCreatingTest extends AbstractEventTestCase
 {

--- a/tests/Commands/Events/QueueDeletedTest.php
+++ b/tests/Commands/Events/QueueDeletedTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\AmqpRabbitManager\Tests\Commands\Events;
 use AvtoDev\AmqpRabbitManager\Commands\Events\QueueDeleted;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\QueueDeleted<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\QueueDeleted
  */
 class QueueDeletedTest extends AbstractEventTestCase
 {

--- a/tests/Commands/Events/QueueDeletingTest.php
+++ b/tests/Commands/Events/QueueDeletingTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\AmqpRabbitManager\Tests\Commands\Events;
 use AvtoDev\AmqpRabbitManager\Commands\Events\QueueDeleting;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\QueueDeleting<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\Commands\Events\QueueDeleting
  */
 class QueueDeletingTest extends AbstractEventTestCase
 {

--- a/tests/Commands/RabbitSetupCommandTest.php
+++ b/tests/Commands/RabbitSetupCommandTest.php
@@ -23,7 +23,7 @@ use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeCreating;
 use AvtoDev\AmqpRabbitManager\Commands\Events\ExchangeDeleting;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\Commands\RabbitSetupCommand<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\Commands\RabbitSetupCommand
  *
  * @group usesExternalServices
  */

--- a/tests/ConnectionsFactoryTest.php
+++ b/tests/ConnectionsFactoryTest.php
@@ -11,7 +11,7 @@ use AvtoDev\AmqpRabbitManager\ConnectionsFactoryInterface;
 use AvtoDev\AmqpRabbitManager\Exceptions\FactoryException;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\ConnectionsFactory<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\ConnectionsFactory
  */
 class ConnectionsFactoryTest extends AbstractTestCase
 {

--- a/tests/Exceptions/FactoryExceptionTest.php
+++ b/tests/Exceptions/FactoryExceptionTest.php
@@ -8,7 +8,7 @@ use AvtoDev\AmqpRabbitManager\Tests\AbstractTestCase;
 use AvtoDev\AmqpRabbitManager\Exceptions\FactoryException;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\Exceptions\FactoryException<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\Exceptions\FactoryException
  */
 class FactoryExceptionTest extends AbstractTestCase
 {

--- a/tests/ExchangesFactoryTest.php
+++ b/tests/ExchangesFactoryTest.php
@@ -11,7 +11,7 @@ use AvtoDev\AmqpRabbitManager\ExchangesFactoryInterface;
 use AvtoDev\AmqpRabbitManager\Exceptions\FactoryException;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\ExchangesFactory<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\ExchangesFactory
  */
 class ExchangesFactoryTest extends AbstractTestCase
 {

--- a/tests/QueuesFactoryTest.php
+++ b/tests/QueuesFactoryTest.php
@@ -11,7 +11,7 @@ use AvtoDev\AmqpRabbitManager\QueuesFactoryInterface;
 use AvtoDev\AmqpRabbitManager\Exceptions\FactoryException;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\QueuesFactory<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\QueuesFactory
  */
 class QueuesFactoryTest extends AbstractTestCase
 {

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -15,7 +15,7 @@ use AvtoDev\AmqpRabbitManager\Commands\RabbitSetupCommand;
 use AvtoDev\AmqpRabbitManager\ConnectionsFactoryInterface;
 
 /**
- * @covers \AvtoDev\AmqpRabbitManager\ServiceProvider<extended>
+ * @covers \AvtoDev\AmqpRabbitManager\ServiceProvider
  */
 class ServiceProviderTest extends AbstractTestCase
 {


### PR DESCRIPTION
## Description

Added Laravel 10 and PHPUnit 10 support

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I wrote unit tests for my code _(if tests is required for my changes)_
- [X] I have made changes in `CHANGELOG.md` file

## Changelog

### Added

- Support Laravel `10.x`
- Support PHPUnit `v10`

### Changed

- Minimal require PHP version now is `8.0.2`
- Composer version up to `2.6.5`
- RabbitMQ version up to `0.13.0`
- Package `mockery/mockery` up to `^1.6`
- Package `phpstan/phpstan` up to `^1.10`
