### PR TITLE
Add Laravel 12 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,9 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: [ '8.1', '8.2', '8.3' ]
+        php: ['8.2', '8.3']
         include:
-          - php: '8.1'
+          - php: '8.2'
             setup: [ basic, lowest ]
             coverage: no
             laravel: '^10.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Laravel `12.x` support
+- Using `docker` with `compose` plugin instead of `docker-compose` for test environment
+
+### Changed
+
+- Minimal require PHP version now is `8.2`
+- Version of `composer` in docker container updated up to `2.8.9`
+- Updated dev dependencies
+
 ## v2.10.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - Minimal require PHP version now is `8.2`
 - Version of `composer` in docker container updated up to `2.8.9`
-- Updated dev dependencies
 
 ## v2.10.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV \
     PHP_AMQP_VERSION="1.11.0" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.7.4 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.8.9 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \

--- a/Makefile
+++ b/Makefile
@@ -14,31 +14,31 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: ## Build docker images, required for current package environment
-	docker-compose build
+	docker compose build
 
 latest: clean ## Install latest php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-stable
+	docker compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-stable
 
 install: clean ## Install regular php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction
+	docker compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction
 
 lowest: clean ## Install lowest php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-lowest
+	docker compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-lowest
 
 test: up ## Execute php tests and linters
-	docker-compose run $(RUN_APP_ARGS) app sh -c "sleep 5 && composer test"
+	docker compose run $(RUN_APP_ARGS) app sh -c "sleep 5 && composer test"
 
 test-cover: up ## Execute php tests with coverage
-	docker-compose run --rm --user "0:0" -e 'XDEBUG_MODE=coverage' app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
+	docker compose run --rm --user "0:0" -e 'XDEBUG_MODE=coverage' app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 up: ## Start services
-	docker-compose up -d
+	docker compose up -d
 
 down: ## Stop services
-	docker-compose down
+	docker compose down
 
 shell: ## Start shell into container with php
-	docker-compose run $(RUN_APP_ARGS) app sh
+	docker compose run $(RUN_APP_ARGS) app sh
 
 clean: ## Remove all dependencies and unimportant files
 	-rm -Rf ./composer.lock ./vendor ./coverage

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ $connection->purgeQueue($queues->make('some-queue-id'));
 
 ### Testing
 
-For package testing we use `phpunit` framework and `docker-ce` + `docker-compose` as develop environment. So, just write into your terminal after repository cloning:
+For package testing we use `phpunit` framework and `docker` with `compose` plugin as develop environment. So, just write into your terminal after repository cloning:
 
 ```shell
 $ make build

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-amqp": "*",
-        "illuminate/support": "~10.0 || ~11.0",
-        "illuminate/console": "~10.0 || ~11.0",
-        "illuminate/events": "~10.0 || ~11.0",
+        "illuminate/support": "~10.0 || ~11.0 || ~12.0",
+        "illuminate/console": "~10.0 || ~11.0 || ~12.0",
+        "illuminate/events": "~10.0 || ~11.0 || ~12.0",
         "symfony/console": "~6.0 || ~7.0",
         "enqueue/amqp-ext": "^0.10.19",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {
-        "laravel/laravel": "~10.0 || ~11.0",
+        "laravel/laravel": "~10.0 || ~11.0 || ~12.0",
         "phpunit/phpunit": "^10.5",
         "mockery/mockery": "^1.6",
         "phpstan/phpstan": "^1.10"

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -117,14 +117,17 @@ class ServiceProvider extends IlluminateServiceProvider
                 $config = $container->make(ConfigRepository::class);
                 $root   = static::getConfigRootKeyName();
 
-                /** @var array<string, array<string, mixed>>, $connections */
+                /** @var array<string, array<string, mixed>> $connections */
                 $connections = (array) $config->get("{$root}.connections");
                 /** @var string|null $default */
                 $default = $config->get("{$root}.default_connection");
 
+                /** @var array<string, mixed> $connection_defaults */
+                $connection_defaults = (array) $config->get("{$root}.connection_defaults");
+
                 return new ConnectionsFactory(
                     $connections,
-                    (array) $config->get("{$root}.connection_defaults"),
+                    $connection_defaults,
                     $default
                 );
             }


### PR DESCRIPTION
## Description

### Added

- Laravel `12.x` support
- Using `docker` with `compose` plugin instead of `docker-compose` for test environment

### Changed

- Minimal require PHP version now is `8.2`
- Version of `composer` in docker container updated up to `2.8.9`
- Updated dev dependencies

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
