### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,12 +27,12 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.2', '8.3']
+        php: ['8.3', '8.4', '8.5']
         include:
-          - php: '8.2'
+          - php: '8.3'
             setup: [ basic, lowest ]
             coverage: no
-            laravel: '^10.0'
+            laravel: '^12.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Laravel `13.x` support
+
+### Changed
+
+- Minimal required PHP version now is `8.3`
+- Minimal Laravel version now is `^12.0`
+- Version of `composer` in docker container updated up to `2.10.0`
+- Version of `php` in docker container updated up to `8.4`
+- Update dev dependencies
+
 ## v2.11.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-alpine
+FROM php:8.4-alpine
 
 ENV \
     # <https://github.com/alanxz/rabbitmq-c>
@@ -7,7 +7,7 @@ ENV \
     PHP_AMQP_VERSION="1.11.0" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.8.9 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.10.0 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
@@ -27,7 +27,7 @@ RUN set -x \
     # workaround for rabbitmq linking issue
     && ln -s /usr/lib /usr/local/lib64 \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-3.3.0 1>/dev/null \
+    && pecl install xdebug-3.5.3 1>/dev/null \
     # this c-library is required for 'php-amqp'
     && ( git clone --branch v${RABBITMQ_VERSION} https://github.com/alanxz/rabbitmq-c.git /tmp/rabbitmq \
         && cd /tmp/rabbitmq \

--- a/composer.json
+++ b/composer.json
@@ -15,20 +15,20 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-amqp": "*",
-        "illuminate/support": "~10.0 || ~11.0 || ~12.0",
-        "illuminate/console": "~10.0 || ~11.0 || ~12.0",
-        "illuminate/events": "~10.0 || ~11.0 || ~12.0",
+        "illuminate/support": "~12.0 || ~13.0",
+        "illuminate/console": "~12.0 || ~13.0",
+        "illuminate/events": "~12.0 || ~13.0",
         "symfony/console": "~6.0 || ~7.0",
         "enqueue/amqp-ext": "^0.10.19",
         "queue-interop/queue-interop": "^0.8"
     },
     "require-dev": {
-        "laravel/laravel": "~10.0 || ~11.0 || ~12.0",
+        "laravel/laravel": "~12.0 || ~13.0",
         "phpunit/phpunit": "^10.5",
-        "mockery/mockery": "^1.6",
-        "phpstan/phpstan": "^1.10"
+        "mockery/mockery": "^1.6.10",
+        "phpstan/phpstan": "^1.12"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Description

### Added

- Laravel `13.x` support

### Changed

- Minimal required PHP version now is `8.3`
- Minimal Laravel version now is `^12.0`
- Version of `composer` in docker container updated up to `2.10.0`
- Version of `php` in docker container updated up to `8.4`
- Update dev dependencies

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
